### PR TITLE
Assign users to Public group on signup

### DIFF
--- a/giza/views.py
+++ b/giza/views.py
@@ -215,6 +215,8 @@ def sign_up(request):
         if custom_user_form.is_valid():
             # create user
             custom_user = custom_user_form.save()
+            public_group = Group.objects.get(name='Public')
+            custom_user.groups.add(public_group)
             custom_user.save()
             registered = True
             return redirect('/')


### PR DESCRIPTION
Now on signup, the form is processed and the new user is assigned to a "Public" group that needs to be created in the admin backend by a superuser. 

Should address https://github.com/artshumrc/giza/issues/94 -- I'll add the buttons for managing collections on the frontend in a separate issue after the Collections data model is adjusted. 

